### PR TITLE
Don't collapse soft line breaks

### DIFF
--- a/src/stateFromElement.js
+++ b/src/stateFromElement.js
@@ -305,7 +305,7 @@ function trimTrailingSpace(text: string, characterMeta: CharacterMetaSeq): TextF
 }
 
 function collapseWhiteSpace(text: string, characterMeta: CharacterMetaSeq): TextFragment {
-  text = text.replace(/[ \t\r\n]/g, ' ');
+  text = text.replace(/[ \t\n]/g, ' ');
   ({text, characterMeta} = trimLeadingSpace(text, characterMeta));
   ({text, characterMeta} = trimTrailingSpace(text, characterMeta));
   let i = text.length;

--- a/test/test-cases.txt
+++ b/test/test-cases.txt
@@ -2,6 +2,10 @@
 {"entityMap":{},"blocks":[{"key":"33nh8","text":"a","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]}
 <p>a</p>
 
+# Line breaks
+{"entityMap":{},"blocks":[{"key":"4goen","text":"a\rb","type":"unstyled","depth":0,"inlineStyleRanges":[],"entityRanges":[]}]}
+<p>a<br>b</p>
+
 # Single inline style
 {"entityMap":{},"blocks":[{"key":"99n0j","text":"asdf","type":"unstyled","depth":0,"inlineStyleRanges":[{"offset":3,"length":1,"style":"BOLD"}],"entityRanges":[]}]}
 <p>asd<strong>f</strong></p>


### PR DESCRIPTION
Fixes https://github.com/sstur/draft-js-import-element/issues/1.

It seems to me this is the correct fix – avoid collapsing `\r` since that is our special linebreak placeholder. What do you say, @sstur?
