### PR TITLE
Add `options` parameter; Support custom styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,28 @@ It was extracted from [React-RTE](https://react-rte.org) and placed into a separ
 
 This project is still under development. If you want to help out, please open an issue to discuss or join us on [Slack](https://draftjs.slack.com/).
 
+## Usage
+
+`stateFromElement` takes a DOM node `element` and returns a DraftJS [ContentState](https://facebook.github.io/draft-js/docs/api-reference-content-state.html).
+
+```javascript
+import {stateFromElement} from 'draft-js-import-element';
+const contentState = stateFromElement(element);
+```
+
+### Options
+
+You can optionally pass a second `Object` argument to `stateFromElement` with the following supported properties:
+
+- `elementStyles`: HTML element name as key, DraftJS style string as value. Example:
+
+        stateFromElement(element, {
+          elementStyles: {
+            // Support `<sup>` (superscript) tag as style:
+            'sup': 'SUPERSCRIPT'
+          }
+        });
+
 ## License
 
 This software is [BSD Licensed](/LICENSE).

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-flow-vars": "^0.3.0",
     "eslint-plugin-react": "^5.0.1",
     "expect": "^1.18.0",
-    "flow-bin": "^0.23.0",
+    "flow-bin": "^0.23.1",
     "jsdom": "^8.4.0",
     "mocha": "^2.4.5",
     "react": "^15.0.1",

--- a/src/__tests__/stateFromElement-test.js
+++ b/src/__tests__/stateFromElement-test.js
@@ -30,13 +30,29 @@ let testCases = testCasesRaw.slice(1).trim().split(SEP).map((text) => {
 });
 
 describe('stateFromElement', () => {
-  let textNode = new TextNode('Hello World');
-  let element = new ElementNode('div', [], [textNode]);
   it('should create content state', () => {
+    let textNode = new TextNode('Hello World');
+    let element = new ElementNode('div', [], [textNode]);
     let contentState = stateFromElement(element);
     let rawContentState = removeBlockKeys(convertToRaw(contentState));
     expect(rawContentState).toEqual(
       {entityMap: {}, blocks: [{text: 'Hello World', type: 'unstyled', depth: 0, inlineStyleRanges: [], entityRanges: []}]}
+    );
+  });
+
+  it('supports custom element styles option', () => {
+    let textNode = new TextNode('Superscript');
+    let element = new ElementNode('sup', [], [textNode]);
+    let wrapperElement = new ElementNode('div', [], [element]);
+    let options = {
+      elementStyles: {
+        sup: 'SUPERSCRIPT',
+      },
+    };
+    let contentState = stateFromElement(wrapperElement, options);
+    let rawContentState = removeBlockKeys(convertToRaw(contentState));
+    expect(rawContentState).toEqual(
+      {entityMap: {}, blocks: [{text: 'Superscript', type: 'unstyled', depth: 0, inlineStyleRanges: [{offset: 0, length: 11, style: 'SUPERSCRIPT'}], entityRanges: []}]}
     );
   });
 });

--- a/src/stateFromElement.js
+++ b/src/stateFromElement.js
@@ -108,8 +108,10 @@ class BlockGenerator {
   blockStack: Array<ParsedBlock>;
   blockList: Array<ParsedBlock>;
   depth: number;
+  options: Object;
 
-  constructor() {
+  constructor(options) {
+    this.options = options || {};
     // This represents the hierarchy as we traverse nested elements; for
     // example [body, ul, li] where we must know li's parent type (ul or ol).
     this.blockStack = [];
@@ -226,7 +228,7 @@ class BlockGenerator {
     let block = this.blockStack.slice(-1)[0];
     let style = block.styleStack.slice(-1)[0];
     let entityKey = block.entityStack.slice(-1)[0];
-    style = addStyleFromTagName(style, tagName);
+    style = addStyleFromTagName(style, tagName, this.options.elementStyles);
     if (ELEM_TO_ENTITY.hasOwnProperty(tagName)) {
       // If the to-entity function returns nothing, use the existing entity.
       entityKey = ELEM_TO_ENTITY[tagName](tagName, element) || entityKey;
@@ -342,7 +344,7 @@ function concatFragments(fragments: Array<TextFragment>): TextFragment {
 }
 
 
-function addStyleFromTagName(styleSet: StyleSet, tagName: string): StyleSet {
+function addStyleFromTagName(styleSet: StyleSet, tagName: string, elementStyles?: Object): StyleSet {
   switch (tagName) {
     case 'b':
     case 'strong': {
@@ -362,12 +364,17 @@ function addStyleFromTagName(styleSet: StyleSet, tagName: string): StyleSet {
       return styleSet.add(INLINE_STYLE.STRIKETHROUGH);
     }
     default: {
+      // User can provide custom styles
+      if (elementStyles && elementStyles[tagName]) {
+        return styleSet.add(elementStyles[tagName]);
+      }
+
       return styleSet;
     }
   }
 }
 
-export default function stateFromElement(element: DOMElement): ContentState {
-  let blocks = new BlockGenerator().process(element);
+export default function stateFromElement(element: DOMElement, options?: Object): ContentState {
+  let blocks = new BlockGenerator(options).process(element);
   return ContentState.createFromBlockArray(blocks);
 }

--- a/src/stateFromElement.js
+++ b/src/stateFromElement.js
@@ -346,28 +346,25 @@ function addStyleFromTagName(styleSet: StyleSet, tagName: string): StyleSet {
   switch (tagName) {
     case 'b':
     case 'strong': {
-      styleSet = styleSet.add(INLINE_STYLE.BOLD);
-      break;
+      return styleSet.add(INLINE_STYLE.BOLD);
     }
     case 'i':
     case 'em': {
-      styleSet = styleSet.add(INLINE_STYLE.ITALIC);
-      break;
+      return styleSet.add(INLINE_STYLE.ITALIC);
     }
     case 'ins': {
-      styleSet = styleSet.add(INLINE_STYLE.UNDERLINE);
-      break;
+      return styleSet.add(INLINE_STYLE.UNDERLINE);
     }
     case 'code': {
-      styleSet = styleSet.add(INLINE_STYLE.CODE);
-      break;
+      return styleSet.add(INLINE_STYLE.CODE);
     }
     case 'del': {
-      styleSet = styleSet.add(INLINE_STYLE.STRIKETHROUGH);
-      break;
+      return styleSet.add(INLINE_STYLE.STRIKETHROUGH);
+    }
+    default: {
+      return styleSet;
     }
   }
-  return styleSet;
 }
 
 export default function stateFromElement(element: DOMElement): ContentState {


### PR DESCRIPTION
I'm writing a rich text editor with custom styles for `<sup>` and `<sub>` tags. This change lets the user define an options object e.g. `{ elementStyles: { sup: 'SUPERSCRIPT' } }` that, when passed to `stateFromElement`, will result in a ContentState with the correct style type.

See README for more notes.

A companion PR has been submitted here: https://github.com/sstur/draft-js-import-html/pull/4

Bonus change: `return` early from `switch` statement in `addStyleFromTagName` instead of using `break` keyword.
