### PR TITLE
Support custom block types

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ You can optionally pass a second `Object` argument to `stateFromElement` with th
           elementStyles: {
             // Support `<sup>` (superscript) tag as style:
             'sup': 'SUPERSCRIPT'
+          },
+
+          blockTypes: {
+            // support `<left>` as a custom block type `leftAlign`
+            'left': 'leftAlign'
           }
         });
 

--- a/src/stateFromElement.js
+++ b/src/stateFromElement.js
@@ -196,6 +196,11 @@ class BlockGenerator {
   }
 
   getBlockTypeFromTagName(tagName: string): string {
+
+    if (this.options && this.options.blockTypes && this.options.blockTypes[tagName]) {
+      return this.options.blockTypes[tagName];
+    }
+
     switch (tagName) {
       case 'li': {
         let parent = this.blockStack.slice(-1)[0];


### PR DESCRIPTION
This can be used in concordance with https://github.com/sstur/draft-js-export-html#blockrenderers
