### PR TITLE
Add block data map based on block markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ You can optionally pass a second `Object` argument to `stateFromElement` with th
           }
         });
 
+- `filterBlockData`: Callback function to set custom block data based on block element. Example:
+        
+        stateFromElement(element, {
+          // `data` is a JS object, `element` is the HTML node for the block 
+          filterBlockData: (data, element) {
+            // Check if the element has the inline style `text-align`
+            if (element.style.textAlign) {
+              // Set `textAlign` to equal the `text-align` CSS property in the block data map
+              data.textAlign = element.style.textAlign;
+            }
+          
+            // Should always return `data`
+            return data;
+          }
+        });
+
 ## License
 
 This software is [BSD Licensed](/LICENSE).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ const contentState = stateFromElement(element);
 
 You can optionally pass a second `Object` argument to `stateFromElement` with the following supported properties:
 
+- `blockRenderFilter`: Callback function to set block type based on HTML tag name. Example:
+
+        stateFromElement(element, {
+            // Should always return null or a valid block type. `tagName` is a lowercase version of the HTML tag name
+            blockRenderFilter: (tagName) => {
+                switch (tagName) {
+                    // This example forces all elements with the h6 tag to be assigned the block quote block type
+                    case 'h6':
+                        // You can import `BLOCK_TYPE` from Draft.js' `draft-js-utils` or use a string
+                        return BLOCK_TYPE.BLOCKQUOTE;
+                    default:
+                        return null;
+                }
+            }
+        });
+
 - `elementStyles`: HTML element name as key, DraftJS style string as value. Example:
 
         stateFromElement(element, {

--- a/src/stateFromElement.js
+++ b/src/stateFromElement.js
@@ -42,6 +42,7 @@ type ParsedBlock = {
   styleStack: Array<StyleSet>;
   entityStack: Array<?Entity>;
   depth: number;
+  data: Object;
 };
 
 type ElementStyles = {[tagName: string]: Style};
@@ -178,18 +179,15 @@ class BlockGenerator {
       text = text.split(SOFT_BREAK_PLACEHOLDER).join('\n');
       // Discard empty blocks (unless otherwise specified).
       if (text.length || includeEmptyBlock) {
-        let blockData = {
-          key: genKey(),
-          text: text,
-          type: block.type,
-          characterList: characterMeta.toList(),
-          depth: block.depth,
-        };
-        if (block.hasOwnProperty('data') && Map.isMap(block.data)) {
-          blockData.data = block.data;
-        }
         contentBlocks.push(
-          new ContentBlock(blockData)
+          new ContentBlock({
+            key: genKey(),
+            text: text,
+            type: block.type,
+            characterList: characterMeta.toList(),
+            depth: block.depth,
+            data: block.hasOwnProperty('data') && Map.isMap(block.data) ? block.data : fromJS({}),
+          })
         );
       }
     });
@@ -249,6 +247,7 @@ class BlockGenerator {
     let type = this.getBlockTypeFromTagName(tagName);
     let hasDepth = canHaveDepth(type);
     let allowRender = !SPECIAL_ELEMENTS.hasOwnProperty(tagName);
+    let data = fromJS({});
     let block: ParsedBlock = {
       tagName: tagName,
       textFragments: [],
@@ -256,6 +255,7 @@ class BlockGenerator {
       styleStack: [NO_STYLE],
       entityStack: [NO_ENTITY],
       depth: hasDepth ? this.depth : 0,
+      data: {},
     };
     if (allowRender) {
       if (this.options && this.options.hasOwnProperty('filterBlockData') && this.options.filterBlockData) {

--- a/src/stateFromElement.js
+++ b/src/stateFromElement.js
@@ -247,7 +247,6 @@ class BlockGenerator {
     let type = this.getBlockTypeFromTagName(tagName);
     let hasDepth = canHaveDepth(type);
     let allowRender = !SPECIAL_ELEMENTS.hasOwnProperty(tagName);
-    let data = fromJS({});
     let block: ParsedBlock = {
       tagName: tagName,
       textFragments: [],

--- a/src/stateFromElement.js
+++ b/src/stateFromElement.js
@@ -48,8 +48,9 @@ type ParsedBlock = {
 type ElementStyles = {[tagName: string]: Style};
 
 type Options = {
+  blockRenderFilter?: null;
   elementStyles?: ElementStyles;
-  filterBlockData?: false;
+  filterBlockData?: null;
 };
 
 const NO_STYLE = OrderedSet();
@@ -199,6 +200,15 @@ class BlockGenerator {
   }
 
   getBlockTypeFromTagName(tagName: string): string {
+    let blockType = null;
+    if (this.options.hasOwnProperty('blockRenderFilter') && this.options.blockRenderFilter) {
+      blockType = this.options.blockRenderFilter(tagName);
+    }
+
+    if (blockType) {
+      return blockType;
+    }
+
     switch (tagName) {
       case 'li': {
         let parent = this.blockStack.slice(-1)[0];

--- a/src/stateFromElement.js
+++ b/src/stateFromElement.js
@@ -259,7 +259,7 @@ class BlockGenerator {
     };
     if (allowRender) {
       if (this.options && this.options.hasOwnProperty('filterBlockData') && this.options.filterBlockData) {
-        block.data = fromJS(this.options.filterBlockData({}, element, block));
+        block.data = fromJS(this.options.filterBlockData({}, element));
       }
       this.blockList.push(block);
       if (hasDepth) {


### PR DESCRIPTION
This adds the ability to add block data based on inline styles or other data attributes on the block element. This allows complete data flow from editor to html to editor. Version 0.5.0 of draft-js-export-html added the ability to use block data to add inline block styles, this adds the ability to use inline styles to add block data.
