### PR TITLE
add atom type to img tag

### DIFF
--- a/src/stateFromElement.js
+++ b/src/stateFromElement.js
@@ -240,6 +240,9 @@ class BlockGenerator {
       case 'figure': {
         return BLOCK_TYPE.ATOMIC;
       }
+      case 'img': {
+        return BLOCK_TYPE.ATOMIC;
+      }
       default: {
         return BLOCK_TYPE.UNSTYLED;
       }


### PR DESCRIPTION
Currently images when converted from HTML -> editor state
do not work unless wrapped in a figure. doing this modification will fix this issue. 