### PR TITLE
[WIP] Fix blockquotes which contain other nodes

### DIFF
--- a/test/test-cases.txt
+++ b/test/test-cases.txt
@@ -80,3 +80,9 @@
   </li>
   <li>Two</li>
 </ol>
+
+# Blockquotes
+{"entityMap":{},"blocks":[]}
+<blockquote cite="http://google.com">
+  <p>Quote here</p>
+</blockquote>


### PR DESCRIPTION
Came here from https://github.com/sstur/draft-js-import-markdown/issues/1

The markdown parser in `draft-js-import-markdown` parses blockquotes perfectly fine, but when the parsed blockquotes are passed to `draft-js-import-element` they get lost.

I aim to implement support for blockquotes in this PR.

- [x] Add failing test to demonstrate it doesn't work
- [ ] Add support for blockquotes